### PR TITLE
Controller and view team management

### DIFF
--- a/src/main/java/todolist/controller/TeamsController.java
+++ b/src/main/java/todolist/controller/TeamsController.java
@@ -5,6 +5,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import todolist.authentication.ManagerUserSession;
 import todolist.dto.EquipoData;
@@ -41,16 +42,17 @@ public class TeamsController {
             model.addAttribute("teams", teams != null ? teams : Collections.emptyList());
             model.addAttribute("loggedIn", true);
             model.addAttribute("usuarioLogeado", usuarioLogeado);
-            model.addAttribute("usuario", usuarioLogeado);
+            model.addAttribute("usuario", usuarioLogeado); // <-- Añadir si se usa en la vista
 
             return "teamsList";
 
         } catch (RuntimeException e) {
-            UsuarioData usuarioLogeado = usuarioService.findById(usuarioId);
+            // Añadir usuarioLogeado incluso en caso de error
+            UsuarioData usuarioLogeado = usuarioService.findById(usuarioId); // <-- Recuperar el usuario
             model.addAttribute("error", "Error al cargar equipos: " + e.getMessage());
             model.addAttribute("loggedIn", true);
             model.addAttribute("usuarioLogeado", usuarioLogeado);
-            model.addAttribute("usuario", usuarioLogeado);
+            model.addAttribute("usuario", usuarioLogeado); // <-- Añadir si se usa en la vista
             return "teamsList";
         }
     }
@@ -61,6 +63,7 @@ public class TeamsController {
         if (usuarioId == null) return "redirect:/login";
 
         try {
+            // Cambiar el nombre de la variable para que coincida con el fragmento
             UsuarioData usuarioLogeado = usuarioService.findById(usuarioId);
             EquipoData equipo = equipoService.recuperarEquipo(teamId);
             List<UsuarioData> miembros = equipoService.usuariosEquipo(teamId);
@@ -115,6 +118,62 @@ public class TeamsController {
         } catch (RuntimeException e) {
             redirectAttributes.addFlashAttribute("error", e.getMessage());
             return "redirect:/teams/" + teamId + "/members";
+        }
+    }
+
+    @GetMapping("/teams/{teamId}/edit")
+    public String mostrarFormularioEdicion(@PathVariable Long teamId, Model model) {
+        Long usuarioId = managerUserSession.usuarioLogeado();
+        if (usuarioId == null) return "redirect:/login";
+
+        // Validar si es admin
+        if (!usuarioService.isAdmin(usuarioId)) {
+            return "redirect:/teams?error=Acceso no autorizado";
+        }
+
+        try {
+            EquipoData equipo = equipoService.recuperarEquipo(teamId);
+            model.addAttribute("equipo", equipo);
+            model.addAttribute("loggedIn", true);
+            model.addAttribute("usuarioLogeado", usuarioService.findById(usuarioId));
+            return "editTeam";
+        } catch (RuntimeException e) {
+            return "redirect:/teams?error=" + e.getMessage();
+        }
+    }
+
+    @PostMapping("/teams/{teamId}/edit")
+    public String editarEquipo(
+            @PathVariable Long teamId,
+            @RequestParam("nombre") String nombre,
+            RedirectAttributes redirectAttributes) {
+
+        Long usuarioId = managerUserSession.usuarioLogeado();
+        if (usuarioId == null || !usuarioService.isAdmin(usuarioId)) {
+            return "redirect:/teams?error=Acceso no autorizado";
+        }
+
+        try {
+            equipoService.renombrarEquipo(teamId, nombre);
+            return "redirect:/teams";
+        } catch (RuntimeException e) {
+            redirectAttributes.addFlashAttribute("error", e.getMessage());
+            return "redirect:/teams/" + teamId + "/edit";
+        }
+    }
+
+    @PostMapping("/teams/{teamId}/delete")
+    public String eliminarEquipo(@PathVariable Long teamId) {
+        Long usuarioId = managerUserSession.usuarioLogeado();
+        if (usuarioId == null || !usuarioService.isAdmin(usuarioId)) {
+            return "redirect:/teams?error=Acceso no autorizado";
+        }
+
+        try {
+            equipoService.eliminarEquipo(teamId);
+            return "redirect:/teams";
+        } catch (RuntimeException e) {
+            return "redirect:/teams?error=" + e.getMessage();
         }
     }
 }

--- a/src/main/java/todolist/dto/UsuarioData.java
+++ b/src/main/java/todolist/dto/UsuarioData.java
@@ -1,5 +1,6 @@
 package todolist.dto;
 
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Objects;
 
@@ -73,5 +74,13 @@ public class UsuarioData {
     @Override
     public int hashCode() {
         return Objects.hash(getId());
+    }
+
+    public String getFechaNacimientoFormateada() {
+        if (fechaNacimiento != null) {
+            SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
+            return sdf.format(fechaNacimiento);
+        }
+        return "No especificada";
     }
 }

--- a/src/main/java/todolist/service/EquipoService.java
+++ b/src/main/java/todolist/service/EquipoService.java
@@ -24,7 +24,6 @@ public class EquipoService {
     @Autowired
     private UsuarioRepository usuarioRepository;
 
-
     @Transactional
     public EquipoData registrar(EquipoData equipo) {
         Optional<Equipo> equipoBD = equipoRepository.findByNombre(equipo.getNombre());
@@ -36,15 +35,6 @@ public class EquipoService {
             Equipo equipoNuevo = modelMapper.map(equipo, Equipo.class);
             equipoNuevo = equipoRepository.save(equipoNuevo);
             return modelMapper.map(equipoNuevo, EquipoData.class);
-        }
-    }
-
-    @Transactional(readOnly = true)
-    public EquipoData findByNombre(String nombre) {
-        Equipo equipo = equipoRepository.findByNombre(nombre).orElse(null);
-        if (equipo == null) return null;
-        else {
-            return modelMapper.map(equipo, EquipoData.class);
         }
     }
 
@@ -163,5 +153,21 @@ public class EquipoService {
 
         equipo.getUsuarios().remove(usuario);
         usuario.getEquipos().remove(equipo);
+    }
+
+    @Transactional
+    public void renombrarEquipo(Long equipoId, String nuevoNombre) {
+        Equipo equipo = equipoRepository.findById(equipoId)
+                .orElseThrow(() -> new EquipoServiceException("Equipo no encontrado"));
+        equipo.setNombre(nuevoNombre);
+        equipoRepository.save(equipo);
+    }
+
+    @Transactional
+    public void eliminarEquipo(Long equipoId) {
+        Equipo equipo = equipoRepository.findById(equipoId)
+                .orElseThrow(() -> new EquipoServiceException("Equipo no encontrado"));
+        equipo.getUsuarios().forEach(usuario -> usuario.getEquipos().remove(equipo));
+        equipoRepository.delete(equipo);
     }
 }

--- a/src/main/java/todolist/service/UsuarioService.java
+++ b/src/main/java/todolist/service/UsuarioService.java
@@ -4,8 +4,6 @@ import todolist.dto.UsuarioData;
 import todolist.model.Usuario;
 import todolist.repository.UsuarioRepository;
 import org.modelmapper.ModelMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,8 +15,6 @@ import java.util.Optional;
 @Service
 public class UsuarioService {
 
-    Logger logger = LoggerFactory.getLogger(UsuarioService.class);
-
     public enum LoginStatus {LOGIN_OK, USER_NOT_FOUND, ERROR_PASSWORD}
 
     @Autowired
@@ -26,13 +22,11 @@ public class UsuarioService {
     @Autowired
     private ModelMapper modelMapper;
 
-    // Método nuevo para verificar existencia de administrador
     @Transactional(readOnly = true)
     public boolean existsByAdmin(boolean admin) {
         return usuarioRepository.existsByAdmin(admin);
     }
 
-    // Nuevo método para cambiar el estado enabled
     @Transactional
     public void toggleUserStatus(Long userId, boolean enabled) {
         Usuario usuario = usuarioRepository.findById(userId)
@@ -53,7 +47,6 @@ public class UsuarioService {
         }
     }
 
-    // Registro modificado para validar administrador único
     @Transactional
     public UsuarioData registrar(UsuarioData usuario) {
         Optional<Usuario> usuarioBD = usuarioRepository.findByEmail(usuario.getEmail());
@@ -64,7 +57,6 @@ public class UsuarioService {
         } else if (usuario.getPassword() == null) {
             throw new UsuarioServiceException("El usuario no tiene password");
         } else {
-            // Validar si el nuevo usuario es admin y ya existe uno
             Usuario usuarioNuevo = modelMapper.map(usuario, Usuario.class);
             usuarioNuevo.setEnabled(true);
             if (usuarioNuevo.isAdmin() && usuarioRepository.existsByAdmin(true)) {
@@ -95,5 +87,12 @@ public class UsuarioService {
         return StreamSupport.stream(usuarios.spliterator(), false)
                 .map(usuario -> modelMapper.map(usuario, UsuarioData.class))
                 .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isAdmin(Long usuarioId) {
+        Usuario usuario = usuarioRepository.findById(usuarioId)
+                .orElseThrow(() -> new UsuarioServiceException("Usuario no encontrado"));
+        return usuario.isAdmin();
     }
 }

--- a/src/main/resources/templates/editTeam.html
+++ b/src/main/resources/templates/editTeam.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="es" xml:lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Editar Equipo</title>
+    <th:block th:insert="~{fragments :: head(titulo='Editar Equipo')}"></th:block>
+</head>
+<body>
+<div class="container-fluid">
+    <div th:replace="~{fragments :: navbar(
+        ${loggedIn},
+        ${usuarioLogeado != null && usuarioLogeado.nombre != null} ? ${usuarioLogeado.nombre} : 'Invitado'
+    )}"></div>
+
+    <div class="row mt-4">
+        <div class="col-md-6 offset-md-3">
+            <div class="card shadow-lg">
+                <div class="card-header bg-warning text-white">
+                    <h1 class="mb-0">
+                        <i class="fas fa-edit mr-2"></i>Editar Equipo
+                    </h1>
+                </div>
+
+                <div class="card-body">
+                    <form th:action="@{/teams/{id}/edit(id=${equipo.id})}" method="post">
+                        <div class="form-group">
+                            <label for="nombre">Nombre del equipo:</label>
+                            <input type="text"
+                                   class="form-control"
+                                   id="nombre"
+                                   th:field="${equipo.nombre}"
+                                   required>
+                        </div>
+                        <button type="submit" class="btn btn-primary">
+                            <i class="fas fa-save mr-1"></i>Guardar cambios
+                        </button>
+                        <a th:href="@{/teams}" class="btn btn-secondary ml-2">
+                            Cancelar
+                        </a>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div th:replace="~{fragments::javascript}"></div>
+</body>
+</html>

--- a/src/main/resources/templates/teamsList.html
+++ b/src/main/resources/templates/teamsList.html
@@ -27,7 +27,7 @@
             <div class="card shadow-lg">
                 <div class="card-header bg-primary text-white">
                     <h3 class="mb-0">
-                        <i class="fas fa-users-cog mr-2"></i>Registered Teams
+                        <i class="fas fa-users-cog mr-2"></i>Equipos Registrados
                     </h3>
                 </div>
 
@@ -46,22 +46,46 @@
                                 th:class="${stat.odd} ? 'table-light' : ''">
                                 <td th:text="${team.id}"></td>
                                 <td>
-                                        <span th:text="${team.nombre}"
-                                              class="font-weight-bold"></span>
+                                    <span th:text="${team.nombre}"
+                                          class="font-weight-bold"></span>
                                 </td>
                                 <td class="text-center">
-                                    <a th:href="@{|/teams/${team.id}/members|}"
-                                       class="btn btn-sm btn-outline-info"
-                                       title="Ver miembros del equipo">
-                                        <i class="fas fa-user-friends mr-1"></i>
-                                        <span class="d-none d-md-inline">Members</span>
-                                    </a>
+                                    <div class="btn-group" role="group">
+                                        <a th:href="@{|/teams/${team.id}/members|}"
+                                           class="btn btn-sm btn-outline-info"
+                                           title="Ver miembros del equipo">
+                                            <i class="fas fa-user-friends mr-1"></i>
+                                            <span class="d-none d-md-inline">Miembros</span>
+                                        </a>
+
+
+                                        <a th:if="${usuarioLogeado != null and usuarioLogeado.admin}"
+                                           th:href="@{|/teams/${team.id}/edit|}"
+                                           class="btn btn-sm btn-outline-warning ml-1"
+                                           title="Editar equipo">
+                                            <i class="fas fa-edit mr-1"></i>
+                                            <span class="d-none d-md-inline">Editar</span>
+                                        </a>
+
+                                        <form th:if="${usuarioLogeado != null and usuarioLogeado.admin}"
+                                              th:action="@{|/teams/${team.id}/delete|}"
+                                              method="post"
+                                              class="d-inline ml-1">
+                                            <button type="submit"
+                                                    class="btn btn-sm btn-outline-danger"
+                                                    title="Eliminar equipo"
+                                                    onclick="return confirm('¿Eliminar este equipo?')">
+                                                <i class="fas fa-trash-alt mr-1"></i>
+                                                <span class="d-none d-md-inline">Eliminar</span>
+                                            </button>
+                                        </form>
+                                    </div>
                                 </td>
                             </tr>
                             <tr th:if="${#lists.isEmpty(teams)}">
                                 <td colspan="3" class="text-center text-muted py-4">
                                     <i class="fas fa-info-circle fa-2x mb-3"></i><br>
-                                    There are no registered teams
+                                    No hay equipos registrados
                                 </td>
                             </tr>
                             </tbody>

--- a/src/main/resources/templates/usersDescription.html
+++ b/src/main/resources/templates/usersDescription.html
@@ -22,12 +22,10 @@
                         <li class="list-group-item">
                             <strong>Email:</strong>
                             <span th:text="${usuario.email} ?: 'No especificado'"></span>
+                        </li>
                         <li class="list-group-item">
                             <strong>Fecha de nacimiento:</strong>
-                            <span th:if="${usuario.fechaNacimiento != null}"
-                                  th:text="${#temporals.format(usuario.fechaNacimiento, 'dd/MM/yyyy')}">
-                            </span>
-                            <span th:if="${usuario.fechaNacimiento == null}">No especificada</span>
+                            <span th:text="${usuario.fechaNacimientoFormateada}"></span>
                         </li>
                     </ul>
                     <a th:href="@{/registered}" class="btn btn-secondary mt-3">Volver a la lista</a>


### PR DESCRIPTION
This PR introduces full support for editing and deleting teams, restricted exclusively to admin users.

#### 🛠 Backend Changes

- **TeamsController.java**  
  - Added new endpoints:
    - `GET /teams/{teamId}/edit` → `mostrarFormularioEdicion()` to display the team edit form.
    - `POST /teams/{teamId}/edit` → `editarEquipo()` to rename a team.
    - `POST /teams/{teamId}/delete` → `eliminarEquipo()` to delete a team.
  - Admin validation integrated using `usuarioService.isAdmin()` to protect access to edit and delete routes.

- **EquipoService.java**  
  - Implemented `renombrarEquipo(Long, String)` for updating team names.
  - Implemented `eliminarEquipo(Long)` for deleting teams and removing associations.

- **EquipoServiceTest.java**  
  - Added `renombrarEquipoTest()` to verify renaming logic.
  - Added `eliminarEquipoTest()` to ensure teams are correctly deleted.

- **UsuarioService.java**  
  - Added `isAdmin(Long usuarioId)` to encapsulate admin validation.

#### 🎨 Frontend Changes

- **editTeam.html**  
  - New Thymeleaf template containing the team name editing form.

- **teamsList.html**  
  - Edit and Delete buttons now appear conditionally only if the logged-in user is an admin.

- **userDescription.html**  
  - Simplified date rendering by replacing raw Thymeleaf formatting with a new helper method.

#### 🧩 Utilities

- **UsuarioData.java**  
  - Added method `getFechaNacimientoFormateada()` to return a clean "dd/MM/yyyy" string or fallback text.

---

This pull request completes the feature for secure team modification and deletion, enhancing both admin control and frontend consistency.in(Long usuarioId)` method to validate admin status.